### PR TITLE
Fix broken image URL for "The Garden of Earthly Delights"

### DIFF
--- a/results.html
+++ b/results.html
@@ -289,7 +289,7 @@
                         {
                             title: "The Garden of Earthly Delights",
                             artist: "Hieronymus Bosch",
-                            imageUrl: "https://upload.wikimedia.org/wikipedia/commons/9/96/The_Garden_of_earthly_delights.jpg/2560px-The_Garden_of_earthly_delights.jpg",
+                            imageUrl: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6d/The_Garden_of_Earthly_Delights_by_Bosch_High_Resolution.jpg/2560px-The_Garden_of_Earthly_Delights_by_Bosch_High_Resolution.jpg",
                         }
                     ]
                 },


### PR DESCRIPTION
This pull request addresses a broken image link for the artwork "The Garden of Earthly Delights" by Hieronymus Bosch. The previous URL was not functioning, and it has been replaced with a new link that points to a high-resolution image.

Changes made:

Updated the imageUrl field to ensure the artwork is displayed correctly.